### PR TITLE
Making message_backward_compatibility.rs tests compile

### DIFF
--- a/tests/message_backward_compatibility.rs
+++ b/tests/message_backward_compatibility.rs
@@ -15,6 +15,20 @@ pub enum Message {
     Group(GroupMessage),
 }
 
+impl From<OriginalMessage> for Message {
+    fn from(o_msg: OriginalMessage) -> Self {
+        match o_msg {
+            OriginalMessage::Switch(m) => Message::Switch(m.into()),
+            OriginalMessage::Clean(m) => Message::Clean(m.into()),
+            OriginalMessage::Group(m) => Message::Group(m.into()),
+            _ => todo!()
+        }
+    }
+}
+
+
+
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SwitchMessage {
     pub task_id_1: usize,
@@ -22,8 +36,44 @@ pub struct SwitchMessage {
     pub some_new_field: usize,
 }
 
+impl From<pueue_lib::network::message::SwitchMessage> for SwitchMessage {
+    fn from(sw: pueue_lib::network::message::SwitchMessage) -> Self {
+        SwitchMessage { task_id_1: sw.task_id_1,
+                        task_id_2: sw.task_id_2,
+                        some_new_field: 0
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CleanMessage {}
+impl From<pueue_lib::network::message::CleanMessage> for CleanMessage {
+    fn from(_o_msg: pueue_lib::network::message::CleanMessage) -> Self {
+        // Do some conversion here
+        CleanMessage {}
+    }
+}
+
+impl From<OriginalGroupMessage> for GroupMessage {
+    fn from(o_msg: OriginalGroupMessage) -> Self {
+        match o_msg {
+            OriginalGroupMessage::Add(s) => GroupMessage::Add(s),
+            OriginalGroupMessage::Remove(s) => GroupMessage::Remove(s),
+            OriginalGroupMessage::List => GroupMessage::List{something: "".to_string()},
+        }
+    }
+}
+
+impl From<GroupMessage> for OriginalGroupMessage {
+    fn from(group_msg: GroupMessage) -> Self {
+        match group_msg {
+            GroupMessage::Add(s) => OriginalGroupMessage::Add(s),
+            GroupMessage::Remove(s) => OriginalGroupMessage::Remove(s),
+            GroupMessage::List{something: _} => OriginalGroupMessage::List,
+        }
+    }
+}
+
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub enum GroupMessage {
@@ -70,7 +120,7 @@ fn test_deserialize_changed_enum_variant() {
     let message = OriginalMessage::Group(OriginalGroupMessage::List);
     let payload_bytes = to_vec(&message).unwrap();
 
-    let message: Message = from_slice(&payload_bytes).unwrap();
+    let message : Message = from_slice::<OriginalMessage>(&payload_bytes).unwrap().into();
     // The serialized message did have an additional field. The deserialization works anyway.
     assert!(matches!(message, Message::Group(_)));
 }

--- a/tests/message_backward_compatibility.rs
+++ b/tests/message_backward_compatibility.rs
@@ -9,6 +9,7 @@ use pueue_lib::network::message::{
 /// This is the main message enum. \
 /// Everything that's communicated in Pueue can be serialized as this enum.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(from="OriginalMessage")]
 pub enum Message {
     Switch(SwitchMessage),
     Clean(CleanMessage),
@@ -25,9 +26,6 @@ impl From<OriginalMessage> for Message {
         }
     }
 }
-
-
-
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SwitchMessage {
@@ -120,7 +118,7 @@ fn test_deserialize_changed_enum_variant() {
     let message = OriginalMessage::Group(OriginalGroupMessage::List);
     let payload_bytes = to_vec(&message).unwrap();
 
-    let message : Message = from_slice::<OriginalMessage>(&payload_bytes).unwrap().into();
+    let message : Message = from_slice(&payload_bytes).unwrap();
     // The serialized message did have an additional field. The deserialization works anyway.
     assert!(matches!(message, Message::Group(_)));
 }


### PR DESCRIPTION
Added example conversion functions for structs to aide in backward
compatibility.

trying to address backward compatibility 