### PR TITLE
Remove default_parallel_tasks setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] -
+
+### Removed
+
+- Remove the `settings.daemon.default_parallel_tasks` setting, as it doesn't have any effect.
+
 ## [0.18.1] - 2021-09-15
 
 ### Added

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -83,8 +83,6 @@ pub struct Client {
 /// All settings which are used by the daemon
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct Daemon {
-    /// How many parallel tasks a group should have by default
-    pub default_parallel_tasks: usize,
     /// Whether a group should be paused as soon as a single task fails
     pub pause_group_on_failure: bool,
     /// Whether the daemon (and all groups) should be paused as soon as a single task fails


### PR DESCRIPTION
This setting currently has no effect. This PR removes it as discussed in https://github.com/Nukesor/pueue/issues/240#issuecomment-933002197.