### PR TITLE
Extract groups from settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Deprecated
 
 - Deprecate the `settings.daemon.groups` setting.
+- Extend `GroupMessage::Add` to also contain the amount of parallel tasks for the created group.
 
 ## [0.18.1] - 2021-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Remove the `settings.daemon.default_parallel_tasks` setting, as it doesn't have any effect.
 
+### Deprecated
+
+- Deprecate the `settings.daemon.groups` setting.
+
 ## [0.18.1] - 2021-09-15
 
 ### Added

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
-use crate::state::{GroupStatus, State};
+use crate::state::{GroupInfo, State};
 use crate::task::Task;
 
 /// This is the main message enum. \
@@ -168,15 +168,14 @@ pub struct EditResponseMessage {
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub enum GroupMessage {
-    Add(String),
+    Add(String, usize),
     Remove(String),
     List,
 }
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct GroupResponseMessage {
-    pub groups: BTreeMap<String, GroupStatus>,
-    pub settings: BTreeMap<String, usize>,
+    pub groups: BTreeMap<String, GroupInfo>,
 }
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
-use crate::state::{GroupInfo, State};
+use crate::state::{Group, State};
 use crate::task::Task;
 
 /// This is the main message enum. \
@@ -179,7 +179,7 @@ pub enum GroupMessage {
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct GroupResponseMessage {
-    pub groups: BTreeMap<String, GroupInfo>,
+    pub groups: BTreeMap<String, Group>,
 }
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -168,8 +168,12 @@ pub struct EditResponseMessage {
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub enum GroupMessage {
+    /// Create a new group with the given name and number of parallel tasks.
+    /// (name, parallel_tasks)
     Add(String, usize),
+    /// Remove the group with the given name.
     Remove(String),
+    /// List all existing groups.
     List,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -320,7 +320,9 @@ fn parse_config(
     let settings = config.try_into::<Settings>()?;
 
     if settings.daemon.groups.is_some() {
-        error!("The `daemon.groups` setting is deprecated.");
+        error!(r#"The `daemon.groups` setting is deprecated.
+                  Please remove it from your config, as it might lead to inconsistent behavior on the next start.
+                  The groups will still be available, as they're now stored in pueued's internal state."#);
     }
 
     // Try to can deserialize the entire configuration

--- a/src/state.rs
+++ b/src/state.rs
@@ -24,6 +24,7 @@ impl Default for GroupStatus {
     }
 }
 
+/// The runtime state of a group.
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct Group {
     pub status: GroupStatus,

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,7 +5,6 @@ use std::sync::{Arc, Mutex};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::network::message::{create_failure_message, Message};
 use crate::settings::{Settings, PUEUE_DEFAULT_GROUP};
 use crate::task::{Task, TaskStatus};
 
@@ -158,29 +157,6 @@ impl State {
         }
 
         Ok(())
-    }
-
-    /// Get an immutable reference to the specified group in this state, if it exists, otherwise
-    /// return a failure message.
-    pub fn get_group<'a, 'b>(&'a self, group: &'b str) -> Result<&'a Group, Message> {
-        self.groups.get(group).ok_or_else(|| {
-            create_failure_message(format!(
-                "Group {} doesn't exists. Use one of these: {:?}",
-                group,
-                self.groups.keys()
-            ))
-        })
-    }
-
-    /// Get a mutable reference to the specified group in this state, if it exists, otherwise
-    /// return a failure message.
-    pub fn get_group_mut<'a, 'b>(&'a mut self, group: &'b str) -> Result<&'a mut Group, Message> {
-        let failure_msg = create_failure_message(format!(
-            "Group {} doesn't exists. Use one of these: {:?}",
-            group,
-            self.groups.keys()
-        ));
-        self.groups.get_mut(group).ok_or(failure_msg)
     }
 
     /// Set the group status (running/paused) for all groups including the default queue.

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,12 +26,12 @@ impl Default for GroupStatus {
 }
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
-pub struct GroupInfo {
+pub struct Group {
     pub status: GroupStatus,
     pub parallel_tasks: usize,
 }
 
-impl Default for GroupInfo {
+impl Default for Group {
     fn default() -> Self {
         Self {
             status: GroupStatus::default(),
@@ -70,7 +70,7 @@ pub struct State {
     /// All tasks currently managed by the daemon.
     pub tasks: BTreeMap<usize, Task>,
     /// All groups
-    pub groups: BTreeMap<String, GroupInfo>,
+    pub groups: BTreeMap<String, Group>,
     /// Used to store an configuration path that has been explicitely specified.
     /// Without this, the default config path will be used instead.
     pub config_path: Option<PathBuf>,
@@ -85,7 +85,7 @@ impl State {
             for (name, parallel_tasks) in settings_groups.iter() {
                 groups.insert(
                     name.clone(),
-                    GroupInfo {
+                    Group {
                         parallel_tasks: *parallel_tasks,
                         ..Default::default()
                     },
@@ -93,7 +93,7 @@ impl State {
             }
         }
         if !groups.contains_key(PUEUE_DEFAULT_GROUP) {
-            groups.insert(PUEUE_DEFAULT_GROUP.to_string(), GroupInfo::default());
+            groups.insert(PUEUE_DEFAULT_GROUP.to_string(), Group::default());
         }
         let mut state = State {
             settings: settings.clone(),
@@ -130,7 +130,7 @@ impl State {
         if self.groups.get(group).is_none() {
             self.groups.insert(
                 group.into(),
-                GroupInfo {
+                Group {
                     status: GroupStatus::Running,
                     parallel_tasks,
                 },
@@ -162,7 +162,7 @@ impl State {
 
     /// Get an immutable reference to the specified group in this state, if it exists, otherwise
     /// return a failure message.
-    pub fn get_group<'a, 'b>(&'a self, group: &'b str) -> Result<&'a GroupInfo, Message> {
+    pub fn get_group<'a, 'b>(&'a self, group: &'b str) -> Result<&'a Group, Message> {
         self.groups.get(group).ok_or_else(|| {
             create_failure_message(format!(
                 "Group {} doesn't exists. Use one of these: {:?}",
@@ -174,10 +174,7 @@ impl State {
 
     /// Get a mutable reference to the specified group in this state, if it exists, otherwise
     /// return a failure message.
-    pub fn get_group_mut<'a, 'b>(
-        &'a mut self,
-        group: &'b str,
-    ) -> Result<&'a mut GroupInfo, Message> {
+    pub fn get_group_mut<'a, 'b>(&'a mut self, group: &'b str) -> Result<&'a mut Group, Message> {
         let failure_msg = create_failure_message(format!(
             "Group {} doesn't exists. Use one of these: {:?}",
             group,

--- a/tests/settings_backward_compatibility.rs
+++ b/tests/settings_backward_compatibility.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use pueue_lib::settings::{Settings, PUEUE_DEFAULT_GROUP};
+use pueue_lib::settings::Settings;
 
 /// From 0.15.0 on, we aim to have full backward compatibility.
 /// For this reason, an old (slightly modified) v0.15.0 serialized settings file
@@ -26,12 +26,15 @@ fn test_restore_from_old_state() -> Result<()> {
     let settings: Settings = Settings::read_with_defaults(true, &Some(old_settings_path))
         .context("Failed to read old config with defaults:")?;
 
-    assert!(settings.daemon.groups.get(PUEUE_DEFAULT_GROUP).is_some());
-    assert_eq!(
-        settings.daemon.groups.get(PUEUE_DEFAULT_GROUP).unwrap(),
-        &1,
-        "The default parallel setting for the 'default' group should be 1."
-    );
-
+    let groups = settings.daemon.groups.unwrap();
+    for group in ["test", "webhook"] {
+        assert!(groups.get(group).is_some());
+        assert_eq!(
+            groups.get(group).unwrap(),
+            &1,
+            "The default parallel setting for the '{}' group should be 1.",
+            group
+        );
+    }
     Ok(())
 }

--- a/tests/state_backward_compatibility.rs
+++ b/tests/state_backward_compatibility.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 
 use pueue_lib::{
     settings::PUEUE_DEFAULT_GROUP,
-    state::{GroupStatus, State},
+    state::{Group, GroupStatus, State},
 };
 
 /// From 0.18.0 on, we aim to have full backward compatibility for our state deserialization.
@@ -41,13 +41,22 @@ fn test_restore_from_old_state() -> Result<()> {
     );
     assert_eq!(
         state.groups.get(PUEUE_DEFAULT_GROUP).unwrap(),
-        &GroupStatus::Paused
+        &Group {
+            status: GroupStatus::Paused,
+            parallel_tasks: 1
+        }
     );
     assert!(
         state.groups.get("test").is_some(),
         "Group 'test' should exist"
     );
-    assert_eq!(state.groups.get("test").unwrap(), &GroupStatus::Running);
+    assert_eq!(
+        state.groups.get("test").unwrap(),
+        &Group {
+            status: GroupStatus::Running,
+            parallel_tasks: 1
+        }
+    );
 
     assert!(state.tasks.get(&3).is_some(), "Task 3 should exist");
     assert_eq!(state.tasks.get(&3).unwrap().command, "ls stash_it");


### PR DESCRIPTION
This is the `pueue-lib` part of https://github.com/Nukesor/pueue/issues/240. It makes the setting `settings.daemon.groups` optional so that a deprecation warning can be displayed when it is present in an old configuration. The `groups` map in `State` now covers both status (`Running`/`Paused`) and number of parallel tasks (which used to be in `settings`). The struct that contains this information is called `GroupInfo`, a name I'm not really happy with.