### PR TITLE
change: Remove group configuration from settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add optional `group` field to CleanMessage.
 - Add optional `parallel_tasks` field to Group create message.
+- Introduced a `Group` struct, which is used to store information about groups in the `State`.
 
 ### Removed
 
@@ -19,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Switch from `async-std` to tokio.
 - Update to rustls 0.20
+- **Breaking:** The type of `State.group` changed from `BTreeMap<String, GroupStatus>` to the new `BTreeMap<String, Group>` struct.
+- **Breaking:** The `GroupResponseMessage` now also uses the new `Group` struct.
 
 ## [0.18.1] - 2021-09-15
 

--- a/src/network/message.rs
+++ b/src/network/message.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
-use crate::state::{GroupStatus, State};
+use crate::state::{Group, State};
 use crate::task::Task;
 
 /// This is the main message enum. \
@@ -178,8 +178,7 @@ pub enum GroupMessage {
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct GroupResponseMessage {
-    pub groups: BTreeMap<String, GroupStatus>,
-    pub settings: BTreeMap<String, usize>,
+    pub groups: BTreeMap<String, Group>,
 }
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]

--- a/src/task.rs
+++ b/src/task.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use serde_derive::{Deserialize, Serialize};
 use strum_macros::Display;
 
-use crate::{aliasing::insert_alias, settings::PUEUE_DEFAULT_GROUP};
+use crate::{aliasing::insert_alias, state::PUEUE_DEFAULT_GROUP};
 
 /// This enum represents the status of the internal task handling of Pueue.
 /// They basically represent the internal task life-cycle.

--- a/tests/settings_backward_compatibility.rs
+++ b/tests/settings_backward_compatibility.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use pueue_lib::settings::{Settings, PUEUE_DEFAULT_GROUP};
+use pueue_lib::settings::Settings;
 
 /// From 0.15.0 on, we aim to have full backward compatibility.
 /// For this reason, an old (slightly modified) v0.15.0 serialized settings file
@@ -23,15 +23,8 @@ fn test_restore_from_old_state() -> Result<()> {
         .join("v0.15.0_settings.yml");
 
     // Open v0.15.0 file and ensure the settings file can be read.
-    let settings: Settings = Settings::read_with_defaults(true, &Some(old_settings_path))
+    Settings::read_with_defaults(true, &Some(old_settings_path))
         .context("Failed to read old config with defaults:")?;
-
-    assert!(settings.daemon.groups.get(PUEUE_DEFAULT_GROUP).is_some());
-    assert_eq!(
-        settings.daemon.groups.get(PUEUE_DEFAULT_GROUP).unwrap(),
-        &1,
-        "The default parallel setting for the 'default' group should be 1."
-    );
 
     Ok(())
 }

--- a/tests/state_backward_compatibility.rs
+++ b/tests/state_backward_compatibility.rs
@@ -2,10 +2,7 @@ use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result};
 
-use pueue_lib::{
-    settings::PUEUE_DEFAULT_GROUP,
-    state::{GroupStatus, State},
-};
+use pueue_lib::state::{GroupStatus, State, PUEUE_DEFAULT_GROUP};
 
 /// From 0.18.0 on, we aim to have full backward compatibility for our state deserialization.
 /// For this reason, an old (slightly modified) v0.18.0 serialized state has been checked in.
@@ -40,14 +37,17 @@ fn test_restore_from_old_state() -> Result<()> {
         "Group 'default' should exist."
     );
     assert_eq!(
-        state.groups.get(PUEUE_DEFAULT_GROUP).unwrap(),
-        &GroupStatus::Paused
+        state.groups.get(PUEUE_DEFAULT_GROUP).unwrap().status,
+        GroupStatus::Paused
     );
     assert!(
         state.groups.get("test").is_some(),
         "Group 'test' should exist"
     );
-    assert_eq!(state.groups.get("test").unwrap(), &GroupStatus::Running);
+    assert_eq!(
+        state.groups.get("test").unwrap().status,
+        GroupStatus::Paused
+    );
 
     assert!(state.tasks.get(&3).is_some(), "Task 3 should exist");
     assert_eq!(state.tasks.get(&3).unwrap().command, "ls stash_it");


### PR DESCRIPTION
Previously, the group configuration was located in the settings file.

However, this lead to some problems as groups can be added and removed
dynamically during runtime.
To sync these changes, we had to save the settings file each time
something changed. This isn't acceptable, as users expected the config
file to be immutable.

To solve this issue, the groups have been removed from the settings
and are now only saved in the state.